### PR TITLE
Added migrations from legacy db to remove unwanted columns and table

### DIFF
--- a/migration.sql
+++ b/migration.sql
@@ -1,0 +1,312 @@
+--
+-- Dropping unwanted tables
+--
+
+
+-- Dropping table  -- archived_channeldescription -- as it is marked for deletion in the database specification document
+DROP TABLE archived_channeldescription;
+-- Dropping table  -- archived_chemistry_generalinformation -- as it is marked for deletion in the database specification document
+DROP TABLE archived_chemistry_generalinformation;
+-- Dropping table  -- archived_geomorphology -- as it is marked for deletion in the database specification document
+DROP TABLE archived_geomorphology;
+-- Dropping table  -- archived_habitatassessmentham_hqi -- as it is marked for deletion in the database specification document
+DROP TABLE archived_habitatassessmentham_hqi;
+-- Dropping table  -- archived_indexofhabitatintegrity -- as it is marked for deletion in the database specification document
+DROP TABLE archived_indexofhabitatintegrity;
+-- Dropping table  -- archived_riparianvegetationindex -- as it is marked for deletion in the database specification document
+DROP TABLE archived_riparianvegetationindex;
+-- Dropping table  -- archived_riparianzonedescription -- as it is marked for deletion in the database specification document
+DROP TABLE archived_riparianzonedescription;
+-- Dropping table  -- archived_sitecondition -- as it is marked for deletion in the database specification document
+DROP TABLE archived_sitecondition;
+-- Dropping table  -- archived_speciesrichness -- as it is marked for deletion in the database specification document
+DROP TABLE archived_speciesrichness;
+-- Dropping table  -- archived_vegetationcover -- as it is marked for deletion in the database specification document
+DROP TABLE archived_vegetationcover;
+-- Dropping table  -- archived_vegetationdistribution -- as it is marked for deletion in the database specification document
+DROP TABLE archived_vegetationdistribution;
+-- Dropping table  -- archived_vegetationinvasion -- as it is marked for deletion in the database specification document
+DROP TABLE archived_vegetationinvasion;
+-- Dropping table  -- archived_vegetationspecieslist -- as it is marked for deletion in the database specification document
+DROP TABLE archived_vegetationspecieslist ;
+-- Dropping table  -- temp_view_archived_chemistry_generalinformation -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_archived_chemistry_generalinformation;
+-- Dropping table  -- temp_view_archived_riparianvegetationindex -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_archived_riparianvegetationindex;
+-- Dropping table  -- temp_view_archiveddata -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_archiveddata;
+-- Dropping table  -- temp_view_indexofhabitatintegrity -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_indexofhabitatintegrity;
+-- Dropping table  -- temp_view_sitegeomorphology -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitegeomorphology;
+-- Dropping table  -- temp_view_sitegeoreference -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitegeoreference;
+-- Dropping table  -- temp_view_siteinformationgeneral -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_siteinformationgeneral;
+-- Dropping table  -- temp_view_siteinformationlocation -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_siteinformationlocation;
+-- Dropping table  -- temp_view_siteinformationregional -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_siteinformationregional;
+-- Dropping table  -- temp_view_sitevisitbiotopeinvertebrates -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitbiotopeinvertebrates;
+-- Dropping table  -- temp_view_sitevisitbiotopeinvertebratesxtababundance -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitbiotopeinvertebratesxtababundance;
+-- Dropping table  -- temp_view_sitevisitbiotopeinvertebratesxtababundancesass4 -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitbiotopeinvertebratesxtababundancesass4;
+-- Dropping table  -- temp_view_sitevisitbiotopeinvertebratesxtababundancesass5 -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitbiotopeinvertebratesxtababundancesass5;
+-- Dropping table  -- temp_view_sitevisitbiotopeinvertebratesxtabscore -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitbiotopeinvertebratesxtabscore;
+-- Dropping table  -- temp_view_sitevisitbiotopeinvertebratesxtabscoresass4 -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitbiotopeinvertebratesxtabscoresass4;
+-- Dropping table  -- temp_view_sitevisitbiotopeinvertebratesxtabscoresass5 -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitbiotopeinvertebratesxtabscoresass5;
+-- Dropping table  -- temp_view_sitevisitbiotopes -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitbiotopes;
+-- Dropping table  -- temp_view_sitevisitbiotopesass_scores -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitbiotopesass_scores;
+-- Dropping table  -- temp_view_sitevisitchannelmodifications -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitchannelmodifications;
+-- Dropping table  -- temp_view_sitevisitchannelmorphology -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitchannelmorphology;
+-- Dropping table  -- temp_view_sitevisitchemistry -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitchemistry;
+-- Dropping table  -- temp_view_sitevisitchemistrygeneralinformation -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitchemistrygeneralinformation;
+-- Dropping table  -- temp_view_sitevisitchemistryxtab -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitchemistryxtab;
+-- Dropping table  -- temp_view_sitevisitfishdatahabitatcover -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitfishdatahabitatcover;
+-- Dropping table  -- temp_view_sitevisitfishsampledetail -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitfishsampledetail;
+-- Dropping table  -- temp_view_sitevisitgeomorphology -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitgeomorphology;
+-- Dropping table  -- temp_view_sitevisitgeoreference -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitgeoreference;
+-- Dropping table  -- temp_view_sitevisithabitatassessment -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisithabitatassessment;
+-- Dropping table  -- temp_view_sitevisitihas -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitihas;
+-- Dropping table  -- temp_view_sitevisitinformationgeneral -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitinformationgeneral;
+-- Dropping table  -- temp_view_sitevisitinformationlocation -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitinformationlocation;
+-- Dropping table  -- temp_view_sitevisitinformationregional -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitinformationregional;
+-- Dropping table  -- temp_view_sitevisitinvertebrates -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitinvertebrates;
+-- Dropping table  -- temp_view_sitevisitlanduse -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitlanduse;
+-- Dropping table  -- temp_view_sitevisitsamplingoccasiongeneralinformation -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitsamplingoccasiongeneralinformation;
+-- Dropping table  -- temp_view_sitevisitsass_scores -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitsass_scores;
+-- Dropping table  -- temp_view_sitevisitsassbiotopes -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitsassbiotopes;
+-- Dropping table  -- temp_view_sitevisitstreamdimension -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitstreamdimension;
+-- Dropping table  -- temp_view_sitevisitsubstratum -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisitsubstratum;
+-- Dropping table  -- temp_view_sitevisittaxonxtababundance -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisittaxonxtababundance;
+-- Dropping table  -- temp_view_sitevisittaxonxtababundancesass4 -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisittaxonxtababundancesass4;
+-- Dropping table  -- temp_view_sitevisittaxonxtababundancesass5 -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisittaxonxtababundancesass5;
+-- Dropping table  -- temp_view_sitevisittaxonxtabscore -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisittaxonxtabscore;
+-- Dropping table  -- temp_view_sitevisittaxonxtabscoresass4 -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisittaxonxtabscoresass4;
+-- Dropping table  -- temp_view_sitevisittaxonxtabscoresass5 -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_sitevisittaxonxtabscoresass5;
+-- Dropping table  -- temp_view_subregion -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_subregion;
+-- Dropping table  -- temp_view_summarizedrivermakeup -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_summarizedrivermakeup;
+-- Dropping table  -- temp_view_user -- as it is marked for deletion in the database specification document
+DROP TABLE temp_view_user;
+-- Dropping table -- assessorsys -- as it is marked for deletion in the database specification documant
+DROP TABLE table;
+-- Dropping table -- bankmods -- as it is marked for deletion in the database specification documant
+DROP TABLE bankmods;
+-- Dropping table -- channeltype -- as it is marked for deletion in the database specification documant
+DROP TABLE channeltype;
+-- Dropping table -- channeltypedetail -- as it is marked for deletion in the database specification documant
+DROP TABLE channeltypedetail;
+-- Dropping table -- cover -- as it is marked for deletion in the database specification documant
+DROP TABLE cover;
+-- Dropping table -- coverestimate -- as it is marked for deletion in the database specification documant
+DROP TABLE coverestimate;
+-- Dropping table -- crosssectionpoint -- as it is marked for deletion in the database specification documant
+DROP TABLE crosssectionpoint;
+-- Dropping table -- dataintegritycheckexclude -- as it is marked for deletion in the database specification documant
+DROP TABLE dataintegritycheckexclude;
+-- Dropping table -- embeddedness -- as it is marked for deletion in the database specification documant
+DROP TABLE embeddedness;
+-- Dropping table -- fishcoverpreference -- as it is marked for deletion in the database specification documant
+DROP TABLE fishcoverpreference;
+-- Dropping table -- fishhabitat -- as it is marked for deletion in the database specification documant
+DROP TABLE fishhabitat;
+-- Dropping table -- fishhabitatepreference -- as it is marked for deletion in the database specification documant
+DROP TABLE fishhabitatepreference;
+-- Dropping table -- fishhabitatesamplingcatchability -- as it is marked for deletion in the database specification documant
+DROP TABLE fishhabitatesamplingcatchability;
+-- Dropping table -- fishintolerance -- as it is marked for deletion in the database specification documant
+DROP TABLE fishintolerance;
+-- Dropping table -- habitattype -- as it is marked for deletion in the database specification documant
+DROP TABLE habitattype;
+-- Dropping table -- hydrotype -- as it is marked for deletion in the database specification documant
+DROP TABLE hydrotype;
+-- Dropping table -- ihicatchment -- as it is marked for deletion in the database specification documant
+DROP TABLE ihicatchment;
+-- Dropping table -- ihigeomorphzone -- as it is marked for deletion in the database specification documant
+DROP TABLE ihigeomorphzone;
+-- Dropping table -- ihiinstream -- as it is marked for deletion in the database specification documant
+DROP TABLE ihiinstream;
+-- Dropping table -- ihiinstreamcomponent -- as it is marked for deletion in the database specification documant
+DROP TABLE ihiinstreamcomponent;
+-- Dropping table -- ihiriperianzone -- as it is marked for deletion in the database specification documant
+DROP TABLE ihiriperianzone;
+-- Dropping table -- ihiriperianzonecomponent -- as it is marked for deletion in the database specification documant
+DROP TABLE ihiriperianzonecomponent;
+-- Dropping table -- ihiseasonality -- as it is marked for deletion in the database specification documant
+DROP TABLE ihiseasonality;
+-- Dropping table -- ihisitevisitcatchment -- as it is marked for deletion in the database specification documant
+DROP TABLE ihisitevisitcatchment;
+-- Dropping table -- ihisitevisitinstream -- as it is marked for deletion in the database specification documant
+DROP TABLE ihisitevisitinstream;
+-- Dropping table -- ihisitevisiteinstreamcomponent -- as it is marked for deletion in the database specification documant
+DROP TABLE ihisitevisiteinstreamcomponent;
+-- Dropping table -- ihisitevisitrivertype -- as it is marked for deletion in the database specification documant
+DROP TABLE ihisitevisitrivertype;
+-- Dropping table -- ihisitevisitseasonality -- as it is marked for deletion in the database specification documant
+DROP TABLE ihisitevisitseasonality;
+-- Dropping table -- ihiwidth -- as it is marked for deletion in the database specification documant
+DROP TABLE ihiwidth;
+-- Dropping table -- landuse -- as it is marked for deletion in the database specification documant
+DROP TABLE landuse;
+-- Dropping table -- levelofconfidence -- as it is marked for deletion in the database specification documant
+DROP TABLE levelofconfidence;
+-- Dropping table -- Ripvegimpact - drop -- as it is marked for deletion in the database specification documant
+DROP TABLE Ripvegimpact;
+-- Dropping table -- rivermakeup -- as it is marked for deletion in the database specification documant
+DROP TABLE rivermakeup;
+-- Dropping table -- Samplingmethod -- as it is marked for deletion in the database specification documant
+DROP TABLE Samplingmethod;
+-- Dropping table -- Sassbiotopespecificbiotope -- as it is marked for deletion in the database specification documant
+DROP TABLE Sassbiotopespecificbiotope;
+-- Dropping table -- Sitechanneltypedetail -- as it is marked for deletion in the database specification documant
+DROP TABLE Sitechanneltypedetail;
+-- Dropping table -- Sitetransaction -- as it is marked for deletion in the database specification documant
+DROP TABLE Sitetransaction;
+-- Dropping table -- Traceriver -- as it is marked for deletion in the database specification documant
+DROP TABLE Traceriver;
+
+--
+-- DROPPING UNWANTED COLUMNS
+--
+
+-- Dropping column -- oldsitecode -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN oldsitecode;
+-- Dropping column -- projectsitenumber -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN projectsitenumber; 
+-- Dropping column -- longitudinalzoneid -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN longitudinalzoneid; 
+-- Dropping column -- reference -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN reference; 
+-- Dropping column -- mapreference -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN mapreference; 
+-- Dropping column -- contrangefrom -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN contrangefrom; 
+-- Dropping column -- contrangeto -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN contrangeto; 
+-- Dropping column -- sitelength -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN sitelength; 
+-- Dropping column -- Source -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN Source; 
+-- Dropping column -- hydrotypeid -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN hydrotypeid; 
+-- Dropping column -- hydrotypenaturalid -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN hydrotypenaturalid; 
+-- Dropping column -- gaugingstation -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN gaugingstation; 
+-- Dropping column -- dwafcode -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN dwafcode; 
+-- Dropping column -- distup -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN distup; 
+-- Dropping column -- distdown -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN distdown; 
+-- Dropping column -- assossysid -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN assossysid; 
+-- Dropping column -- assocsysdist -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN assocsysdist; 
+-- Dropping column -- assocsysname -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN assocsysname; 
+-- Dropping column -- Notify -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN Notify; 
+-- Dropping column -- permitrequired -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN permitrequired; 
+-- Dropping column -- permitdetails -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN permitdetails; 
+-- Dropping column -- permitacquired -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN permitacquired; 
+-- Dropping column -- validityofpermit -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN validityofpermit; 
+-- Dropping column -- Key -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN Key; 
+-- Dropping column -- keyavailability -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN keyavailability; 
+-- Dropping column -- farm on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN farm; 
+-- Dropping column -- farmregistrationcode -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN farmregistrationcode; 
+-- Dropping column -- georeferencecomment -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN georeferencecomment; 
+-- Dropping column -- mapprojection -- on table -- site -- as it is marked for deletion in the database specification document
+ALTER TABLE site DROP COLUMN mapprojection; 
+-- Dropping column -- Time -- on table -- sitevisit -- as it is marked for deletion in the database specification document
+ALTER TABLE sitevisit DROP COLUMN Time; 
+-- Dropping column -- rain -- on table -- sitevisit -- as it is marked for deletion in the database specification document
+ALTER TABLE sitevisit DROP COLUMN rain; 
+-- Dropping column -- raincomment -- on table -- sitevisit -- as it is marked for deletion in the database specification document
+ALTER TABLE sitevisit DROP COLUMN raincomment; 
+-- Dropping column -- embeddednessid -- on table -- sitevisit -- as it is marked for deletion in the database specification document
+ALTER TABLE sitevisit DROP COLUMN embeddednessid; 
+-- Dropping column -- fastflow -- on table -- sitevisit -- as it is marked for deletion in the database specification document
+ALTER TABLE sitevisit DROP COLUMN fastflow; 
+-- Dropping column -- fastflowname -- on table -- sitevisit -- as it is marked for deletion in the database specification document
+ALTER TABLE sitevisit DROP COLUMN fastflowname; 
+-- Dropping column -- waterfiltered -- on table -- sitevisit -- as it is marked for deletion in the database specification document
+ALTER TABLE sitevisit DROP COLUMN waterfiltered; 
+-- Dropping column -- volfiltered -- on table -- sitevisit -- as it is marked for deletion in the database specification document
+ALTER TABLE sitevisit DROP COLUMN volfiltered; 
+-- Dropping column -- samples -- on table -- sitevisit -- as it is marked for deletion in the database specification document
+ALTER TABLE sitevisit DROP COLUMN samples; 
+-- Dropping column -- analysis -- on table -- sitevisit -- as it is marked for deletion in the database specification document
+ALTER TABLE sitevisit DROP COLUMN analysis; 
+-- Dropping column -- frozen -- on table -- sitevisit -- as it is marked for deletion in the database specification document
+ALTER TABLE sitevisit DROP COLUMN frozen; 
+-- Dropping column -- prev -- on table -- sitevisit -- as it is marked for deletion in the database specification document
+ALTER TABLE sitevisit DROP COLUMN prev; 
+-- Dropping column -- sampleinstitute -- on table -- sitevisit -- as it is marked for deletion in the database specification document
+ALTER TABLE sitevisit DROP COLUMN sampleinstitute; 
+-- Dropping column -- canopycovercomment -- on table -- sitevisit -- as it is marked for deletion in the database specification document
+ALTER TABLE sitevisit DROP COLUMN canopycovercomment; 
+-- Dropping column -- habitatintegritycomment -- on table -- sitevisit -- as it is marked for deletion in the database specification document
+ALTER TABLE sitevisit DROP COLUMN habitatintegritycomment; 
+-- Dropping column -- sassdatacomment -- on table -- sitevisit -- as it is marked for deletion in the database specification document
+ALTER TABLE sitevisit DROP COLUMN sassdatacomment; 
+-- Dropping column -- fishowner -- on table -- sitevisit -- as it is marked for deletion in the database specification document
+ALTER TABLE sitevisit DROP COLUMN fishowner; 
+-- Dropping column -- fishassessor -- on table -- sitevisit -- as it is marked for deletion in the database specification document
+ALTER TABLE sitevisit DROP COLUMN fishassessor; 
+-- Dropping column -- ripirianowner -- on table -- sitevisit -- as it is marked for deletion in the database specification document
+ALTER TABLE sitevisit DROP COLUMN ripirianowner; 
+-- Dropping column -- ripirianassessor -- on table -- sitevisit -- as it is marked for deletion in the database specification document
+ALTER TABLE sitevisit DROP COLUMN ripirianassessor; 
+-- Dropping column -- waterchemistryowner -- on table -- sitevisit -- as it is marked for deletion in the database specification document
+ALTER TABLE sitevisit DROP COLUMN waterchemistryowner; 
+-- Dropping column -- waterchemistryassessor -- on table -- sitevisit -- as it is marked for deletion in the database specification document
+ALTER TABLE sitevisit DROP COLUMN waterchemistryassessor; 
+-- Dropping column -- channeltypeid -- on table -- sitevisit -- as it is marked for deletion in the database specification document
+ALTER TABLE sitevisit DROP COLUMN channeltypeid; 


### PR DESCRIPTION
See #60, supercedes #73 

@sonlinux this was what I was expecting for the migration script. It should not contain the full schema definition, only the changes from the original schema to the new schema. For any subsequent changes the workflow should be:

* restore the **original** database to your local copy
* add any new schema changes to migrations.sql
* run the migrations.sql against the local copy
* verify that the updated copy has the intended changes
* commit your changes to migration.sql
* make a PR with you updates explaining the reason for these changes.

Note that ideally your comments in the SQL file should reference a ticket number which explains why you are making the change.

Please review this PR by testing it against a fresh restore of the original database on your system and then give me an LGTM if you are happy for it to be applied.

